### PR TITLE
Set explicit select:disabled opacity

### DIFF
--- a/src/styles/highlights/index.css
+++ b/src/styles/highlights/index.css
@@ -96,6 +96,10 @@ dialog {
     width: 90%;
   }
 
+  & select:disabled {
+    opacity: 0.6;
+  }
+
   & select:hover:disabled {
     cursor: not-allowed;
   }


### PR DESCRIPTION
# Description of Changes

Set opacity level on `select:disabled` explicitly for Safari.