### PR TITLE
Update highlights-api-helper to work with highlights API

### DIFF
--- a/src/scripts/highlights/highlights-api-helper.ts
+++ b/src/scripts/highlights/highlights-api-helper.ts
@@ -15,12 +15,10 @@ interface Highlight {
 }
 
 export const getSources = async (): Promise<Array<Source>> =>
-  await fetch(`${PUBLIC_HIGHLIGHTS_API_URL}/sources`)
-    .then(res => res.json())
-    .then(json => json.sources);
+  await fetch(`${PUBLIC_HIGHLIGHTS_API_URL}/sources`).then(res => res.json());
 
 export const getRandomHighlight = async (): Promise<Highlight> =>
-  await fetch(`${PUBLIC_HIGHLIGHTS_API_URL}/random`).then(res => res.json());
+  await fetch(`${PUBLIC_HIGHLIGHTS_API_URL}/highlights/random`).then(res => res.json());
 
 export const getHighlightsWithQuery = async (queryStr: string): Promise<Array<Highlight>> =>
   await fetch(`${PUBLIC_HIGHLIGHTS_API_URL}/highlights?${queryStr}`).then(res => res.json());

--- a/test/unit/scripts/highlights/highlights-api-helper.test.ts
+++ b/test/unit/scripts/highlights/highlights-api-helper.test.ts
@@ -13,13 +13,13 @@ describe('Highlights API Helper', () => {
   beforeEach(() => vi.clearAllMocks());
 
   test('getSources()', async () => {
-    const mockResponse = { sources: [{ id: 1, title: 'Foo', type: 'BOOK' }] };
+    const mockResponse = [{ id: 1, title: 'Foo', type: 'BOOK' }];
     mockFetchResponse(mockResponse);
 
     const response = await getSources();
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(response).toEqual(mockResponse.sources);
+    expect(response).toEqual(mockResponse);
   });
 
   test('getRandomHighlight()', async () => {


### PR DESCRIPTION
# Description of Changes

Update project to use `highlights` as a backend instead of `highlights-api`
